### PR TITLE
Fix no-unsafe-negation test file to trigger oxlint warning

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -11,7 +11,7 @@
   "sortPackageJson": {
     "sortScripts": true
   },
-  "ignorePatterns": ["dist/", "bundle/"],
+  "ignorePatterns": ["dist/", "bundle/", "tests/javascript/"],
   "sortImports": {
     "groups": [
       "builtin",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,6 +5,7 @@
     "dist",
     "bundle",
     "src/__graphql__",
-    "schema.graphql"
+    "schema.graphql",
+    "tests/javascript"
   ]
 }

--- a/tests/javascript/no-unsafe-negation.js
+++ b/tests/javascript/no-unsafe-negation.js
@@ -1,5 +1,5 @@
-if ((!key) in object) {
+if (!key in object) {
 }
 
-if ((!obj) instanceof Ctor) {
+if (!obj instanceof Ctor) {
 }


### PR DESCRIPTION
Fix no-unsafe-negation test file to trigger oxlint warning

The test file used parenthesized negations like `(!key) in object`,
which oxlint considers unambiguous and does not flag. The no-unsafe-negation
rule only triggers on the bare form `!key in object` where operator
precedence is genuinely unclear.

Also add tests/javascript to .oxlintrc.json ignorePatterns so the
pre-commit hook does not auto-fix intentionally buggy test fixtures.

Fix no-unsafe-negation test file to trigger oxlint warning

The test file used parenthesized negations like `(!key) in object`,
which oxlint considers unambiguous and does not flag. The no-unsafe-negation
rule only triggers on the bare form `!key in object` where operator
precedence is genuinely unclear.

Also add .prettierignore (used by oxfmt) with tests/javascript so the
formatter does not re-parenthesize the intentionally unsafe code in
test fixtures before the pre-commit hook commits them.